### PR TITLE
feat: 댓글 CRUD 기능 구현

### DIFF
--- a/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.scheduleapiv2.comment.dto.CommentCreateRequest;
 import org.example.scheduleapiv2.comment.dto.CommentResponse;
+import org.example.scheduleapiv2.comment.dto.CommentUpdateRequest;
 import org.example.scheduleapiv2.comment.service.CommentService;
 import org.example.scheduleapiv2.common.util.SessionUtils;
 import org.springframework.http.HttpStatus;
@@ -34,5 +35,16 @@ public class CommentController {
     @GetMapping
     public ResponseEntity<List<CommentResponse>> getCommentsByScheduleId(@PathVariable Long scheduleId) {
         return new ResponseEntity<>(commentService.getCommentsByScheduleId(scheduleId), HttpStatus.OK);
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(
+            @PathVariable("commentId") Long commentId,
+            @Valid @RequestBody CommentUpdateRequest commentRequest,
+            HttpServletRequest httpRequest
+    ) {
+        Long sessionUserId = SessionUtils.getUserId(httpRequest);
+
+        return new ResponseEntity<>(commentService.updateComment(commentId, commentRequest, sessionUserId), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
@@ -5,7 +5,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.scheduleapiv2.comment.dto.CommentCreateRequest;
 import org.example.scheduleapiv2.comment.dto.CommentResponse;
-import org.example.scheduleapiv2.comment.entity.Comment;
 import org.example.scheduleapiv2.comment.service.CommentService;
 import org.example.scheduleapiv2.common.util.SessionUtils;
 import org.springframework.http.HttpStatus;
@@ -30,5 +29,10 @@ public class CommentController {
         Long sessionUserId = SessionUtils.getUserId(request);
 
         return new ResponseEntity<>(commentService.createComment(scheduleId, commentRequest, sessionUserId), HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CommentResponse>> getCommentsByScheduleId(@PathVariable Long scheduleId) {
+        return new ResponseEntity<>(commentService.getCommentsByScheduleId(scheduleId), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package org.example.scheduleapiv2.comment.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.scheduleapiv2.comment.dto.CommentCreateRequest;
 import org.example.scheduleapiv2.comment.dto.CommentResponse;
@@ -10,6 +11,8 @@ import org.example.scheduleapiv2.common.util.SessionUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/schedules/{scheduleId}/comments")
@@ -21,7 +24,7 @@ public class CommentController {
     @PostMapping
     public ResponseEntity<CommentResponse> createComment(
             @PathVariable("scheduleId") Long scheduleId,
-            @RequestBody CommentCreateRequest commentRequest,
+            @Valid @RequestBody CommentCreateRequest commentRequest,
             HttpServletRequest request
     ) {
         Long sessionUserId = SessionUtils.getUserId(request);

--- a/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
@@ -47,4 +47,15 @@ public class CommentController {
 
         return new ResponseEntity<>(commentService.updateComment(commentId, commentRequest, sessionUserId), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable("commentId") Long commentId,
+            HttpServletRequest httpRequest
+    ) {
+        Long sessionUserId = SessionUtils.getUserId(httpRequest);
+        commentService.deleteComment(commentId, sessionUserId);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/controller/CommentController.java
@@ -1,0 +1,31 @@
+package org.example.scheduleapiv2.comment.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.example.scheduleapiv2.comment.dto.CommentCreateRequest;
+import org.example.scheduleapiv2.comment.dto.CommentResponse;
+import org.example.scheduleapiv2.comment.entity.Comment;
+import org.example.scheduleapiv2.comment.service.CommentService;
+import org.example.scheduleapiv2.common.util.SessionUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/schedules/{scheduleId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CommentResponse> createComment(
+            @PathVariable("scheduleId") Long scheduleId,
+            @RequestBody CommentCreateRequest commentRequest,
+            HttpServletRequest request
+    ) {
+        Long sessionUserId = SessionUtils.getUserId(request);
+
+        return new ResponseEntity<>(commentService.createComment(scheduleId, commentRequest, sessionUserId), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/dto/CommentCreateRequest.java
@@ -1,8 +1,10 @@
 package org.example.scheduleapiv2.comment.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class CommentCreateRequest {
+    @NotBlank(message = "내용을 입력해주세요.")
     private String contents;
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,8 @@
+package org.example.scheduleapiv2.comment.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CommentCreateRequest {
+    private String contents;
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/dto/CommentResponse.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/dto/CommentResponse.java
@@ -1,0 +1,37 @@
+package org.example.scheduleapiv2.comment.dto;
+
+import lombok.Getter;
+import org.example.scheduleapiv2.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentResponse {
+
+    private final Long id;
+    private final String contents;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+    private final Long userId;
+    private final Long scheduleId;
+
+    public CommentResponse(Long id, String contents, LocalDateTime createdAt, LocalDateTime modifiedAt, Long userId, Long scheduleId) {
+        this.id = id;
+        this.contents = contents;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.userId = userId;
+        this.scheduleId = scheduleId;
+    }
+
+    public static CommentResponse of(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getContents(),
+                comment.getCreatedAt(),
+                comment.getModifiedAt(),
+                comment.getUser().getId(),
+                comment.getSchedule().getId()
+        );
+    }
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,10 @@
+package org.example.scheduleapiv2.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CommentUpdateRequest {
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String contents;
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/entity/Comment.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/entity/Comment.java
@@ -23,4 +23,10 @@ public class Comment extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
+
+    public Comment(String contents, User user, Schedule schedule) {
+        this.contents = contents;
+        this.user = user;
+        this.schedule = schedule;
+    }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/entity/Comment.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/entity/Comment.java
@@ -29,4 +29,8 @@ public class Comment extends BaseEntity {
         this.user = user;
         this.schedule = schedule;
     }
+
+    public void updateContents(String contents) {
+        this.contents = contents;
+    }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/entity/Comment.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/entity/Comment.java
@@ -1,0 +1,26 @@
+package org.example.scheduleapiv2.comment.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.scheduleapiv2.common.entity.BaseEntity;
+import org.example.scheduleapiv2.schedule.entity.Schedule;
+import org.example.scheduleapiv2.user.entity.User;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Comment extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String contents;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "schedule_id")
+    private Schedule schedule;
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
@@ -1,10 +1,17 @@
 package org.example.scheduleapiv2.comment.repository;
 
 import org.example.scheduleapiv2.comment.entity.Comment;
+import org.example.scheduleapiv2.common.error.GlobalErrorCode;
+import org.example.scheduleapiv2.common.exception.ApiException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findCommentsByScheduleId(Long scheduleId);
+
+    default Comment findByIdOrElseThrow(Long commentId) {
+        return findById(commentId).orElseThrow(() ->
+                new ApiException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.example.scheduleapiv2.comment.repository;
+
+import org.example.scheduleapiv2.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package org.example.scheduleapiv2.comment.repository;
 import org.example.scheduleapiv2.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findCommentsByScheduleId(Long scheduleId);
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
@@ -1,0 +1,35 @@
+package org.example.scheduleapiv2.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.scheduleapiv2.comment.dto.CommentCreateRequest;
+import org.example.scheduleapiv2.comment.dto.CommentResponse;
+import org.example.scheduleapiv2.comment.entity.Comment;
+import org.example.scheduleapiv2.comment.repository.CommentRepository;
+import org.example.scheduleapiv2.common.error.GlobalErrorCode;
+import org.example.scheduleapiv2.common.exception.ApiException;
+import org.example.scheduleapiv2.schedule.entity.Schedule;
+import org.example.scheduleapiv2.schedule.repository.ScheduleRepository;
+import org.example.scheduleapiv2.user.entity.User;
+import org.example.scheduleapiv2.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    public CommentResponse createComment(Long scheduleId, CommentCreateRequest commentRequest, Long sessionUserId) {
+        User user = userRepository.findById(sessionUserId).orElseThrow(() ->
+                new ApiException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+
+        Schedule schedule = scheduleRepository.findByIdOrElseThrow(scheduleId);
+
+        Comment comment = new Comment(commentRequest.getContents(), user, schedule);
+        Comment savedComment = commentRepository.save(comment);
+
+        return CommentResponse.of(savedComment);
+    }
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
@@ -12,6 +12,9 @@ import org.example.scheduleapiv2.schedule.repository.ScheduleRepository;
 import org.example.scheduleapiv2.user.entity.User;
 import org.example.scheduleapiv2.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class CommentService {
     private final UserRepository userRepository;
     private final ScheduleRepository scheduleRepository;
 
+    @Transactional
     public CommentResponse createComment(Long scheduleId, CommentCreateRequest commentRequest, Long sessionUserId) {
         User user = userRepository.findById(sessionUserId).orElseThrow(() ->
                 new ApiException(GlobalErrorCode.RESOURCE_NOT_FOUND));
@@ -31,5 +35,14 @@ public class CommentService {
         Comment savedComment = commentRepository.save(comment);
 
         return CommentResponse.of(savedComment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByScheduleId(Long scheduleId) {
+        scheduleRepository.findByIdOrElseThrow(scheduleId);
+
+        return commentRepository.findCommentsByScheduleId(scheduleId).stream()
+                .map(CommentResponse::of)
+                .toList();
     }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
@@ -1,5 +1,7 @@
 package org.example.scheduleapiv2.comment.service;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.scheduleapiv2.comment.dto.CommentCreateRequest;
@@ -56,8 +58,9 @@ public class CommentService {
         SessionUtils.assertUserIsOwner(sessionUserId, comment.getUser().getId());
 
         comment.updateContents(commentRequest.getContents());
+        Comment updatedComment = commentRepository.saveAndFlush(comment);
 
-        return CommentResponse.of(comment);
+        return CommentResponse.of(updatedComment);
     }
 
     public void deleteComment(Long commentId, Long sessionUserId) {

--- a/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
@@ -59,4 +59,12 @@ public class CommentService {
 
         return CommentResponse.of(comment);
     }
+
+    public void deleteComment(Long commentId, Long sessionUserId) {
+        Comment comment = commentRepository.findByIdOrElseThrow(commentId);
+
+        SessionUtils.assertUserIsOwner(sessionUserId, comment.getUser().getId());
+
+        commentRepository.delete(comment);
+    }
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/service/CommentService.java
@@ -1,12 +1,15 @@
 package org.example.scheduleapiv2.comment.service;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.scheduleapiv2.comment.dto.CommentCreateRequest;
 import org.example.scheduleapiv2.comment.dto.CommentResponse;
+import org.example.scheduleapiv2.comment.dto.CommentUpdateRequest;
 import org.example.scheduleapiv2.comment.entity.Comment;
 import org.example.scheduleapiv2.comment.repository.CommentRepository;
 import org.example.scheduleapiv2.common.error.GlobalErrorCode;
 import org.example.scheduleapiv2.common.exception.ApiException;
+import org.example.scheduleapiv2.common.util.SessionUtils;
 import org.example.scheduleapiv2.schedule.entity.Schedule;
 import org.example.scheduleapiv2.schedule.repository.ScheduleRepository;
 import org.example.scheduleapiv2.user.entity.User;
@@ -44,5 +47,16 @@ public class CommentService {
         return commentRepository.findCommentsByScheduleId(scheduleId).stream()
                 .map(CommentResponse::of)
                 .toList();
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long commentId, CommentUpdateRequest commentRequest, Long sessionUserId) {
+        Comment comment = commentRepository.findByIdOrElseThrow(commentId);
+
+        SessionUtils.assertUserIsOwner(sessionUserId, comment.getUser().getId());
+
+        comment.updateContents(commentRequest.getContents());
+
+        return CommentResponse.of(comment);
     }
 }

--- a/src/main/java/org/example/scheduleapiv2/schedule/error/ScheduleErrorCode.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/error/ScheduleErrorCode.java
@@ -1,0 +1,15 @@
+package org.example.scheduleapiv2.schedule.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.scheduleapiv2.common.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ScheduleErrorCode implements ErrorCode {
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 일정을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/example/scheduleapiv2/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/repository/ScheduleRepository.java
@@ -1,13 +1,13 @@
 package org.example.scheduleapiv2.schedule.repository;
 
-import org.example.scheduleapiv2.common.error.GlobalErrorCode;
 import org.example.scheduleapiv2.common.exception.ApiException;
 import org.example.scheduleapiv2.schedule.entity.Schedule;
+import org.example.scheduleapiv2.schedule.error.ScheduleErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     default Schedule findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() ->
-                new ApiException(GlobalErrorCode.RESOURCE_NOT_FOUND));
+                new ApiException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
     }
 }

--- a/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
@@ -58,8 +58,9 @@ public class ScheduleService {
         SessionUtils.assertUserIsOwner(sessionUserId, schedule.getUser().getId());
 
         schedule.updateTitleAndContents(request.getTitle(), request.getContents());
+        Schedule updateSchedule = scheduleRepository.saveAndFlush(schedule);
 
-        return ScheduleResponse.of(schedule);
+        return ScheduleResponse.of(updateSchedule);
     }
 
     @Transactional


### PR DESCRIPTION
## 개요
댓글 생성, 조회, 수정, 삭제 기능을 구현했습니다.  
Schedule과 Comment 엔티티 간 연관관계 매핑 및 예외 처리 로직도 포함됩니다.

## 주요 변경 사항
- `Comment` 엔티티 생성 및 매핑
  - `@ManyToOne` 단방향 매핑 (User, Schedule)
  - 외래키: `user_id`, `schedule_id`
- 댓글 CRUD API 구현 (Controller, Service, Repository)
- 유효성 검증 및 예외 처리 추가

## 참고
- 연관관계: 단방향 `@ManyToOne`  