### PR TITLE
feat: 일정 목록 페이징 조회 기능 구현

### DIFF
--- a/src/main/java/org/example/scheduleapiv2/comment/dto/CommentPagingResponse.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/dto/CommentPagingResponse.java
@@ -1,0 +1,30 @@
+package org.example.scheduleapiv2.comment.dto;
+
+import lombok.Getter;
+import org.example.scheduleapiv2.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentPagingResponse {
+    private final String contents;
+    private final String name;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+    public CommentPagingResponse(String contents, String name, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.contents = contents;
+        this.name = name;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static CommentPagingResponse of(Comment comment, String name) {
+        return new CommentPagingResponse(
+                comment.getContents(),
+                name,
+                comment.getCreatedAt(),
+                comment.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
@@ -3,6 +3,8 @@ package org.example.scheduleapiv2.comment.repository;
 import org.example.scheduleapiv2.comment.entity.Comment;
 import org.example.scheduleapiv2.common.error.GlobalErrorCode;
 import org.example.scheduleapiv2.common.exception.ApiException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -16,4 +18,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     }
 
     int countByScheduleId(Long scheduleId);
+
+    Page<Comment> findByScheduleId(Long scheduleId, Pageable pageable);
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
@@ -14,4 +14,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         return findById(commentId).orElseThrow(() ->
                 new ApiException(GlobalErrorCode.RESOURCE_NOT_FOUND));
     }
+
+    int countByScheduleId(Long scheduleId);
 }

--- a/src/main/java/org/example/scheduleapiv2/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/controller/ScheduleController.java
@@ -6,9 +6,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.scheduleapiv2.common.util.SessionUtils;
 import org.example.scheduleapiv2.schedule.dto.ScheduleCreateRequest;
+import org.example.scheduleapiv2.schedule.dto.SchedulePagingResponse;
 import org.example.scheduleapiv2.schedule.dto.ScheduleResponse;
 import org.example.scheduleapiv2.schedule.dto.ScheduleUpdateRequest;
 import org.example.scheduleapiv2.schedule.service.ScheduleService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,8 +33,12 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ScheduleResponse>> findAllSchedules() {
-        return new ResponseEntity<>(scheduleService.findAllSchedules(), HttpStatus.OK);
+    public ResponseEntity<List<SchedulePagingResponse>> findAllSchedules(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        return new ResponseEntity<>(scheduleService.findAllSchedules(pageRequest), HttpStatus.OK);
     }
 
     @GetMapping("/{scheduleId}")

--- a/src/main/java/org/example/scheduleapiv2/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/controller/ScheduleController.java
@@ -5,10 +5,7 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.scheduleapiv2.common.util.SessionUtils;
-import org.example.scheduleapiv2.schedule.dto.ScheduleCreateRequest;
-import org.example.scheduleapiv2.schedule.dto.SchedulePagingResponse;
-import org.example.scheduleapiv2.schedule.dto.ScheduleResponse;
-import org.example.scheduleapiv2.schedule.dto.ScheduleUpdateRequest;
+import org.example.scheduleapiv2.schedule.dto.*;
 import org.example.scheduleapiv2.schedule.service.ScheduleService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -43,8 +40,11 @@ public class ScheduleController {
     }
 
     @GetMapping("/{scheduleId}")
-    public ResponseEntity<ScheduleResponse> findScheduleById(@PathVariable("scheduleId") Long scheduleId) {
-        return new ResponseEntity<>(scheduleService.findScheduleById(scheduleId), HttpStatus.OK);
+    public ResponseEntity<ScheduleWithCommentResponse> findScheduleById(
+            @PathVariable("scheduleId") Long scheduleId,
+            @PageableDefault(page = 0, size = 10, sort = "modifiedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return new ResponseEntity<>(scheduleService.findScheduleById(scheduleId, pageable), HttpStatus.OK);
     }
 
     @PutMapping("/{scheduleId}")

--- a/src/main/java/org/example/scheduleapiv2/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/controller/ScheduleController.java
@@ -12,6 +12,9 @@ import org.example.scheduleapiv2.schedule.dto.ScheduleUpdateRequest;
 import org.example.scheduleapiv2.schedule.service.ScheduleService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,11 +37,9 @@ public class ScheduleController {
 
     @GetMapping
     public ResponseEntity<List<SchedulePagingResponse>> findAllSchedules(
-            @RequestParam(defaultValue = "0") Integer page,
-            @RequestParam(defaultValue = "10") Integer size
-    ) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-        return new ResponseEntity<>(scheduleService.findAllSchedules(pageRequest), HttpStatus.OK);
+            @PageableDefault(page = 0, size = 10, sort = "modifiedAt", direction = Sort.Direction.DESC) Pageable pageable
+            ) {
+        return new ResponseEntity<>(scheduleService.findAllSchedules(pageable), HttpStatus.OK);
     }
 
     @GetMapping("/{scheduleId}")

--- a/src/main/java/org/example/scheduleapiv2/schedule/dto/SchedulePagingResponse.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/dto/SchedulePagingResponse.java
@@ -1,0 +1,38 @@
+package org.example.scheduleapiv2.schedule.dto;
+
+import lombok.Getter;
+import org.example.scheduleapiv2.schedule.entity.Schedule;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SchedulePagingResponse {
+
+    private final String title;
+    private final String contents;
+    private final int commentCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+    private final String name;
+
+
+    public SchedulePagingResponse(String title, String contents, int commentCount, LocalDateTime createdAt, LocalDateTime modifiedAt, String name) {
+        this.title = title;
+        this.contents = contents;
+        this.commentCount = commentCount;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.name = name;
+    }
+
+    public static SchedulePagingResponse of(Schedule schedule, int commentCount, String username) {
+        return new SchedulePagingResponse(
+                schedule.getTitle(),
+                schedule.getContents(),
+                commentCount,
+                schedule.getCreatedAt(),
+                schedule.getModifiedAt(),
+                username
+        );
+    }
+}

--- a/src/main/java/org/example/scheduleapiv2/schedule/dto/ScheduleResponse.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/dto/ScheduleResponse.java
@@ -1,10 +1,13 @@
 package org.example.scheduleapiv2.schedule.dto;
 
 import lombok.Getter;
+import org.example.scheduleapiv2.comment.dto.CommentResponse;
 import org.example.scheduleapiv2.schedule.entity.Schedule;
 import org.example.scheduleapiv2.user.entity.User;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class ScheduleResponse {

--- a/src/main/java/org/example/scheduleapiv2/schedule/dto/ScheduleWithCommentResponse.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/dto/ScheduleWithCommentResponse.java
@@ -1,0 +1,44 @@
+package org.example.scheduleapiv2.schedule.dto;
+
+import lombok.Getter;
+import org.example.scheduleapiv2.comment.dto.CommentPagingResponse;
+import org.example.scheduleapiv2.comment.dto.CommentResponse;
+import org.example.scheduleapiv2.schedule.entity.Schedule;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class ScheduleWithCommentResponse {
+
+    private final Long id;
+    private final String title;
+    private final String contents;
+    private final Long userId;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+    private final List<CommentPagingResponse> comments;
+
+
+    public ScheduleWithCommentResponse(Long id, String title, String contents, Long userId, LocalDateTime createdAt, LocalDateTime modifiedAt, List<CommentPagingResponse> comments) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+        this.userId = userId;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.comments = comments;
+    }
+
+    public static ScheduleWithCommentResponse of(Schedule schedule, List<CommentPagingResponse> commentPage) {
+        return new ScheduleWithCommentResponse(
+                schedule.getId(),
+                schedule.getTitle(),
+                schedule.getContents(),
+                schedule.getId(),
+                schedule.getCreatedAt(),
+                schedule.getModifiedAt(),
+                commentPage
+        );
+    }
+}

--- a/src/main/java/org/example/scheduleapiv2/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/repository/ScheduleRepository.java
@@ -3,6 +3,8 @@ package org.example.scheduleapiv2.schedule.repository;
 import org.example.scheduleapiv2.common.exception.ApiException;
 import org.example.scheduleapiv2.schedule.entity.Schedule;
 import org.example.scheduleapiv2.schedule.error.ScheduleErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -10,4 +12,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
         return findById(id).orElseThrow(() ->
                 new ApiException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
     }
+
+    Page<Schedule> findAll(Pageable pageable);
 }

--- a/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
@@ -1,20 +1,21 @@
 package org.example.scheduleapiv2.schedule.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.scheduleapiv2.comment.repository.CommentRepository;
 import org.example.scheduleapiv2.common.error.GlobalErrorCode;
 import org.example.scheduleapiv2.common.exception.ApiException;
 import org.example.scheduleapiv2.common.util.SessionUtils;
 import org.example.scheduleapiv2.schedule.dto.ScheduleCreateRequest;
+import org.example.scheduleapiv2.schedule.dto.SchedulePagingResponse;
 import org.example.scheduleapiv2.schedule.dto.ScheduleResponse;
 import org.example.scheduleapiv2.schedule.dto.ScheduleUpdateRequest;
 import org.example.scheduleapiv2.schedule.entity.Schedule;
 import org.example.scheduleapiv2.schedule.repository.ScheduleRepository;
 import org.example.scheduleapiv2.user.entity.User;
 import org.example.scheduleapiv2.user.repository.UserRepository;
-import org.springframework.http.HttpStatus;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
     private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public ScheduleResponse createSchedule(ScheduleCreateRequest request, Long sessionUserId) {
@@ -38,9 +40,13 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public List<ScheduleResponse> findAllSchedules() {
-        return scheduleRepository.findAll().stream()
-                .map(ScheduleResponse::of)
+    public List<SchedulePagingResponse> findAllSchedules(PageRequest pageRequest) {
+        return scheduleRepository.findAll(pageRequest).getContent().stream()
+                .map(schedule -> {
+                    int commentCount = commentRepository.countByScheduleId(schedule.getId());
+                    User user = userRepository.findByIdOrElseThrow(schedule.getUser().getId());
+                    return SchedulePagingResponse.of(schedule, commentCount, user.getName());
+                })
                 .toList();
     }
 

--- a/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
@@ -14,6 +14,7 @@ import org.example.scheduleapiv2.schedule.repository.ScheduleRepository;
 import org.example.scheduleapiv2.user.entity.User;
 import org.example.scheduleapiv2.user.repository.UserRepository;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,8 +41,8 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public List<SchedulePagingResponse> findAllSchedules(PageRequest pageRequest) {
-        return scheduleRepository.findAll(pageRequest).getContent().stream()
+    public List<SchedulePagingResponse> findAllSchedules(Pageable pageable) {
+        return scheduleRepository.findAll(pageable).getContent().stream()
                 .map(schedule -> {
                     int commentCount = commentRepository.countByScheduleId(schedule.getId());
                     User user = userRepository.findByIdOrElseThrow(schedule.getUser().getId());

--- a/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
@@ -1,18 +1,18 @@
 package org.example.scheduleapiv2.schedule.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.scheduleapiv2.comment.dto.CommentPagingResponse;
+import org.example.scheduleapiv2.comment.entity.Comment;
 import org.example.scheduleapiv2.comment.repository.CommentRepository;
 import org.example.scheduleapiv2.common.error.GlobalErrorCode;
 import org.example.scheduleapiv2.common.exception.ApiException;
 import org.example.scheduleapiv2.common.util.SessionUtils;
-import org.example.scheduleapiv2.schedule.dto.ScheduleCreateRequest;
-import org.example.scheduleapiv2.schedule.dto.SchedulePagingResponse;
-import org.example.scheduleapiv2.schedule.dto.ScheduleResponse;
-import org.example.scheduleapiv2.schedule.dto.ScheduleUpdateRequest;
+import org.example.scheduleapiv2.schedule.dto.*;
 import org.example.scheduleapiv2.schedule.entity.Schedule;
 import org.example.scheduleapiv2.schedule.repository.ScheduleRepository;
 import org.example.scheduleapiv2.user.entity.User;
 import org.example.scheduleapiv2.user.repository.UserRepository;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -52,10 +52,16 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public ScheduleResponse findScheduleById(Long scheduleId) {
+    public ScheduleWithCommentResponse findScheduleById(Long scheduleId, Pageable pageable) {
         Schedule schedule = scheduleRepository.findByIdOrElseThrow(scheduleId);
+        List<CommentPagingResponse> commentPage = commentRepository.findByScheduleId(scheduleId, pageable).getContent().stream()
+                .map(comment -> {
+                    User user = userRepository.findByIdOrElseThrow(comment.getUser().getId());
+                    return CommentPagingResponse.of(comment, user.getName());
+                })
+                .toList();
 
-        return ScheduleResponse.of(schedule);
+        return ScheduleWithCommentResponse.of(schedule, commentPage);
     }
 
     @Transactional


### PR DESCRIPTION
## 구현 내용
- 일정 목록 조회 시 Pageable 적용하여 페이징 처리
- 댓글 개수와 작성자 이름을 포함한 SchedulePagingResponse 반환
- @PageableDefault 적용, modifiedAt 기준 최신순 정렬
- Service 레이어에서 댓글 수 조회 및 작성자명 매핑
- 단건 일정 조회(findScheduleById) 시 댓글 목록도 페이징 처리