### PR TITLE
feat: 일정 및 사용자 삭제 시 연관 댓글/일정 안전 삭제 구현

### DIFF
--- a/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findCommentsByScheduleId(Long scheduleId);
@@ -20,4 +21,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     int countByScheduleId(Long scheduleId);
 
     Page<Comment> findByScheduleId(Long scheduleId, Pageable pageable);
+
+    void deleteByScheduleId(Long id);
 }

--- a/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/comment/repository/CommentRepository.java
@@ -23,4 +23,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByScheduleId(Long scheduleId, Pageable pageable);
 
     void deleteByScheduleId(Long id);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/org/example/scheduleapiv2/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/repository/ScheduleRepository.java
@@ -14,4 +14,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     }
 
     Page<Schedule> findAll(Pageable pageable);
+
+    void deleteByUserId(Long id);
 }

--- a/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
+++ b/src/main/java/org/example/scheduleapiv2/schedule/service/ScheduleService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -81,6 +82,8 @@ public class ScheduleService {
         Schedule schedule = scheduleRepository.findByIdOrElseThrow(scheduleId);
 
         SessionUtils.assertUserIsOwner(sessionUserId, schedule.getUser().getId());
+
+        commentRepository.deleteByScheduleId(schedule.getId());
 
         scheduleRepository.delete(schedule);
     }

--- a/src/main/java/org/example/scheduleapiv2/user/service/UserService.java
+++ b/src/main/java/org/example/scheduleapiv2/user/service/UserService.java
@@ -1,8 +1,10 @@
 package org.example.scheduleapiv2.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.scheduleapiv2.comment.repository.CommentRepository;
 import org.example.scheduleapiv2.common.exception.ApiException;
 import org.example.scheduleapiv2.common.util.SessionUtils;
+import org.example.scheduleapiv2.schedule.repository.ScheduleRepository;
 import org.example.scheduleapiv2.security.config.PasswordEncoder;
 import org.example.scheduleapiv2.user.dto.UserCreateRequest;
 import org.example.scheduleapiv2.user.dto.UserLoginResponse;
@@ -24,6 +26,8 @@ import java.util.List;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final CommentRepository commentRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -71,6 +75,10 @@ public class UserService {
         User user = userRepository.findByIdOrElseThrow(userId);
 
         SessionUtils.assertUserIsOwner(sessionUserId, user.getId());
+
+        commentRepository.deleteByUserId(user.getId());
+
+        scheduleRepository.deleteByUserId(user.getId());
 
         userRepository.delete(user);
     }


### PR DESCRIPTION
## 구현 내용

- 일정 삭제 시 연관 댓글 먼저 삭제 후 Schedule 삭제
- 사용자 삭제 시 연관 댓글과 일정 먼저 삭제 후 User 삭제
- 단방향 관계 유지